### PR TITLE
Fix compilation with Intel compilers.

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -85,7 +85,7 @@ ifeq ($(USE_COMPILER), gnu)
 else ifeq ($(USE_COMPILER), intel)
   CC:=icc
   F90:=ifort
-  EXTRAFLAGS := -DIFORT
+  EXTRAFLAGS := -D__INTEL_COMPILER
 endif
 
 


### PR DESCRIPTION
An `IFORT` macro was defined in the Makefile but the code uses an `__INTEL_COMPILER` macro.